### PR TITLE
Fix spreadsheet cell formula evaluation

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,8 +660,10 @@ document.addEventListener('DOMContentLoaded', () => {
             let calculatedThisPass = false;
             
             pending.forEach(cellId => {
-                const formula = (formulas.get(cellId) || '0').trim();
-                const expression = (formula.startsWith('=') ? formula.slice(1) : formula).replace(/,/g, '.');
+                const rawFormula = formulas.get(cellId) ?? '';
+                const trimmed = rawFormula.trim();
+                let expression = trimmed === '' ? '0' : (trimmed.startsWith('=') ? trimmed.slice(1) : trimmed);
+                expression = expression.replace(/,/g, '.');
                 
                 const dependencies = [...expression.matchAll(/[A-Z]+\d+/gi)].map(match => match[0].toUpperCase());
                 const allDepsResolved = dependencies.every(dep => values.has(dep));
@@ -695,11 +697,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
         allInputs.forEach(input => {
             const cellId = input.id.toUpperCase();
+            const rawFormula = formulas.get(cellId) ?? '';
+            const trimmed = rawFormula.trim();
             const value = values.get(cellId);
             const index = parseInt(input.dataset.index, 10);
             const role = input.dataset.role;
 
-            if (value === undefined || isNaN(value)) {
+            if (trimmed === '') {
+                input.value = '';
+                input.classList.remove('error');
+                state.tiers[index].rates[role] = 0;
+            } else if (value === undefined || isNaN(value)) {
                 input.value = "#ERRO!";
                 input.classList.add('error');
                 state.tiers[index].rates[role] = 0;


### PR DESCRIPTION
## Summary
- handle empty formulas as blank cells
- show `#ERRO!` only for invalid expressions
- keep original formulas for editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852c2982508833189c741203a838884