### PR TITLE
Implement contract range override and sensitivity buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,15 @@
             }
             const formatDate = (d) => d && d.seconds ? new Date(d.seconds * 1000).toLocaleDateString('pt-BR', { timeZone: 'UTC' }) : 'N/A';
             const formatPercent = (v) => new Intl.NumberFormat('pt-BR', { style: 'percent', minimumFractionDigits: 3, maximumFractionDigits: 3 }).format(v || 0);
+
+            function getContractTier(contract, model) {
+                if (!model || !Array.isArray(model.tiers)) return null;
+                if (contract.range) {
+                    const idx = parseInt(contract.range, 10) - 1;
+                    return model.tiers[idx] || null;
+                }
+                return model.tiers.find(t => contract.value >= t.rangeInf && (t.rangeSup === null || contract.value <= t.rangeSup));
+            }
             
             // --- Data Sorting ---
             function getSortedEmployees() {
@@ -388,7 +397,7 @@
                 let totalCommissions = 0;
                 if (activeModel && activeModel.tiers) {
                     state.contracts.forEach(contract => {
-                        const tier = activeModel.tiers.find(t => contract.value >= t.rangeInf && (t.rangeSup === null || contract.value <= t.rangeSup));
+                        const tier = getContractTier(contract, activeModel);
                         if (tier && contract.participants) {
                             contract.participants.forEach(employeeId => {
                                 if(tier.rates && tier.rates[employeeId]) {
@@ -436,7 +445,7 @@
                 let totalCommissions = 0;
                 if (activeModel && activeModel.tiers) {
                     filteredContracts.forEach(contract => {
-                        const tier = activeModel.tiers.find(t => contract.value >= t.rangeInf && (t.rangeSup === null || contract.value <= t.rangeSup));
+                        const tier = getContractTier(contract, activeModel);
                         if (tier && contract.participants) {
                             contract.participants.forEach(employeeId => {
                                 if (tier.rates && tier.rates[employeeId]) {
@@ -460,11 +469,11 @@
                                 <option value="scenario2" ${scenario === 'scenario2' ? 'selected' : ''}>Cenário 2</option>
                                 <option value="scenario3" ${scenario === 'scenario3' ? 'selected' : ''}>Cenário 3</option>
                             </select>
-                            <label for="employeeSensitivitySelect" class="font-medium">Sensibilidade:</label>
-                            <select id="employeeSensitivitySelect" class="form-input w-64">
-                                <option value="all" ${state.selectedSensitivityEmployee === 'all' ? 'selected' : ''}>Todos os Funcionários</option>
-                                ${state.employees.map(emp => `<option value="${emp.id}" ${state.selectedSensitivityEmployee === emp.id ? 'selected' : ''}>${emp.name}</option>`).join('')}
-                            </select>
+                            <label class="font-medium">Sensibilidade:</label>
+                            <div class="flex flex-wrap gap-2">
+                                <button type="button" class="sensitivity-btn btn text-sm ${state.selectedSensitivityEmployee === 'all' ? 'btn-primary' : ''}" data-id="all">Todos</button>
+                                ${state.employees.map(emp => `<button type="button" class="sensitivity-btn btn text-sm ${state.selectedSensitivityEmployee === emp.id ? 'btn-primary' : ''}" data-id="${emp.id}">${emp.name}</button>`).join('')}
+                            </div>
                         </div>
                     </div>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -552,7 +561,7 @@
                     let totalBonus = 0;
                     relevantContracts.forEach(contract => {
                         if (contract.participants?.includes(emp.id)) {
-                            const tier = activeModel.tiers.find(t => contract.value >= t.rangeInf && (t.rangeSup === null || contract.value <= t.rangeSup));
+                            const tier = getContractTier(contract, activeModel);
                             if (tier && tier.rates && tier.rates[emp.id]) {
                                 totalBonus += contract.value * tier.rates[emp.id];
                             }
@@ -758,6 +767,14 @@
                     <input name="value" type="number" step="0.01" placeholder="Valor do Contrato" class="form-input text-sm" value="${item.value || ''}" required>
                     <label class="text-xs">Data de Fechamento</label>
                     <input name="closingDate" type="date" class="form-input text-sm" value="${closingDate}" required>
+                    <label class="text-xs">Faixa de Comissão</label>
+                    <select name="range" class="form-input text-sm">
+                        <option value="">Automático</option>
+                        ${(() => {
+                            const model = state.commissionModels.find(m => m.id === state.settings.activeCommissionModelId) || state.commissionModels[0];
+                            return (model?.tiers || []).map((t, i) => `<option value="${i+1}" ${item.range == i+1 ? 'selected' : ''}>Faixa ${i+1}</option>`).join('');
+                        })()}
+                    </select>
                     
                     <div class="pt-2">
                         <div class="text-sm font-medium">Cenários do Contrato:</div>
@@ -819,7 +836,7 @@
                         content = `<div class="card text-center"><p class="text-orange-500">Nenhum modelo de comissão ativo foi configurado no sistema.</p></div>`;
                     } else {
                         const commissionRows = myContracts.map(contract => {
-                            const tier = activeModel.tiers.find(t => contract.value >= t.rangeInf && (t.rangeSup === null || contract.value <= t.rangeSup));
+                            const tier = getContractTier(contract, activeModel);
                             const myRate = tier && tier.rates ? (tier.rates[employeeProfile.id] || 0) : 0;
                             const myBonus = contract.value * myRate;
                             totalBonus += myBonus;
@@ -854,9 +871,11 @@
                             state.selectedAnalysisScenario = e.target.value;
                             render();
                         });
-                        document.getElementById('employeeSensitivitySelect')?.addEventListener('change', e => {
-                            state.selectedSensitivityEmployee = e.target.value;
-                            render();
+                        document.querySelectorAll('.sensitivity-btn').forEach(btn => {
+                            btn.addEventListener('click', () => {
+                                state.selectedSensitivityEmployee = btn.dataset.id;
+                                render();
+                            });
                         });
                     }
                 }
@@ -978,6 +997,8 @@
                         if (type === 'contract') {
                             data.value = parseFloat(data.value);
                             data.closingDate = new Date(data.closingDate + 'T00:00:00');
+                            const rangeVal = formData.get('range');
+                            data.range = rangeVal ? parseInt(rangeVal, 10) : null;
                             data.participants = formData.getAll('participants');
                             data.scenarios = formData.getAll('scenarios');
                         }
@@ -1155,6 +1176,7 @@
                         commercialProperty: row["Propriedade Comercial"],
                         value: parseFloat(row.Valor.replace(/[^0-9,-]+/g,"").replace(",", ".")) || 0,
                         closingDate: closingDate,
+                        range: null,
                         participants: participants,
                         scenarios: scenarios,
                     };


### PR DESCRIPTION
## Summary
- allow selecting commission range per contract with new 'range' field
- add helper `getContractTier` to respect manual range when calculating bonuses
- switch sensitivity employee selector to individual buttons
- support new range field when importing CSV

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68793409300c833191e94d35f0e7bbb1